### PR TITLE
Update swift syntax dependency to point at new official apple location

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "509.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Apple have moved their swift repos into a separate GitHub organisation, see https://www.swift.org/blog/swiftlang-github/.

This means that repos depending on Swift syntax in the new location, and this framework, get warnings in xcode about conflicting dependency resolution. So this PR just updates to the new location to avoid this conflict.